### PR TITLE
Fix. Debian package deps

### DIFF
--- a/.github/workflows/rust-tag-release.yml
+++ b/.github/workflows/rust-tag-release.yml
@@ -41,3 +41,4 @@ jobs:
         env:
           GHR_PATH: build/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHR_DRAFT: yes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ required-features = [ "editor" ]
 
 [package.metadata.deb]
 name = "acr-mirror"
-depends = "jq"
+depends = "jq, libssl-dev"
 maintainer-scripts = "lib/debian"
 assets = [
     [ "target/release/acr", "opt/acr/bin/acr", "755" ],


### PR DESCRIPTION
- Add libssl as a dependency
- Enabling draft on release