### PR TITLE
Enable legacy support workaround

### DIFF
--- a/src/content/registry.rs
+++ b/src/content/registry.rs
@@ -50,8 +50,9 @@ impl Registry {
         let mut repo = repo.into();
         let mut namespace = namespace.into();
 
-        if repo.starts_with("t_") {
+        if repo.starts_with("_tenant_") {
             if let Some((tenant, _repo)) = repo.split_once("/") {
+                let tenant = tenant.trim_start_matches("_tenant_");
                 namespace = format!("{tenant}.{namespace}");
                 repo = _repo.to_string();
                 info!("Applied tenant workaround, namespace -> {namespace}, repo -> {repo}");

--- a/src/content/registry.rs
+++ b/src/content/registry.rs
@@ -4,7 +4,7 @@ use lifec::prelude::{SpecialAttribute, ThunkContext};
 use lifec::state::AttributeIndex;
 use lifec_poem::RoutePlugin;
 use poem::{Request, Response};
-use tracing::{debug, event, Level, error};
+use tracing::{debug, event, Level, error, info};
 
 use crate::hosts_config::MirrorHost;
 
@@ -47,8 +47,16 @@ impl Registry {
     where
         P: RoutePlugin + SpecialAttribute,
     {
-        let repo = repo.into();
-        let namespace = namespace.into();
+        let mut repo = repo.into();
+        let mut namespace = namespace.into();
+
+        if repo.starts_with("t_") {
+            if let Some((tenant, _repo)) = repo.split_once("/") {
+                namespace = format!("{tenant}.{namespace}");
+                repo = _repo.to_string();
+                info!("Applied tenant workaround, namespace -> {namespace}, repo -> {repo}");
+            }
+        }
 
         // Check if the request uri ends with the suffix value of the header, if not then return 503 Service Unavailable
         let accept_if_header = request.header(consts::ACCEPT_IF_SUFFIX_HEADER);

--- a/src/plugins/mirror/default_host.rs
+++ b/src/plugins/mirror/default_host.rs
@@ -14,7 +14,34 @@ impl DefaultHost {
         let config = HostsConfig::new(None::<String>);
 
         let mut host = RegistryHost::new(address.into())
-            .enable_resolve();
+            .enable_resolve()
+            .enable_pull();
+        
+        if insecure {
+            host = host.skip_verify();
+        }
+
+        if let Some(suffix_match) = suffix_match {
+            let suffix_match = suffix_match.into();
+            host = host.add_header(crate::consts::ACCEPT_IF_SUFFIX_HEADER, suffix_match.clone());
+            host = host.add_header(crate::consts::ENABLE_MIRROR_IF_SUFFIX_HEADER, suffix_match);
+        }
+
+        if let Some(streamable_format) = streamable_format {
+            host = host.add_header(crate::consts::UPGRADE_IF_STREAMABLE_HEADER, streamable_format.into());
+        }
+
+        config.add_host(host)
+    }
+
+    /// Returns a host config that is capable of handling azurecr.io/_tenant_ requests
+    /// 
+    pub fn get_legacy_supported_hosts_config(host: impl Into<String>, address: impl Into<String>, insecure: bool, suffix_match: Option<impl Into<String>>, streamable_format: Option<impl Into<String>>) -> HostsConfig {
+        let config = HostsConfig::new(Some(host.into())).enable_legacy_support();
+
+        let mut host = RegistryHost::new(address.into())
+            .enable_resolve()
+            .enable_pull();
         
         if insecure {
             host = host.skip_verify();

--- a/src/plugins/mirror/mirror_host.rs
+++ b/src/plugins/mirror/mirror_host.rs
@@ -11,7 +11,7 @@ impl MirrorHost {
     pub fn get_hosts_config(server: impl Into<String>, host: impl Into<String>, insecure: bool, upgrade_streamable_format: Option<impl Into<String>>) -> HostsConfig {
         let config = HostsConfig::new(Some(server));
 
-        let mut host = RegistryHost::new(host).enable_resolve();
+        let mut host = RegistryHost::new(host).enable_resolve().enable_pull();
 
         if insecure {
             host = host.skip_verify();


### PR DESCRIPTION
Containerd versions under 1.7 do not support the _default host feature. To workaround this, this change includes the ability to encode the tenant prefix in the image reference path. The mirror knows how to decode this into the correct image reference.

For example, `test.azurecr.io/hello-world:latest` can instead be written as `azurecr.io/_tenant_test/hello-world:latest` and the mirror would decode it back to the former.

