### PR TITLE
Minimum enable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,4 @@ query-guest-commands.sh
 query-guest-state.sh
 output.resp
 .test
+.test_handle_config

--- a/lib/debian/acr-mirror.postinst
+++ b/lib/debian/acr-mirror.postinst
@@ -2,7 +2,7 @@
 set -e
 
 cd /opt/acr/bin
-./acr init
+./acr init --min_init
 
 #DEBHELPER#
 

--- a/src/bin/shared/cli.rs
+++ b/src/bin/shared/cli.rs
@@ -100,10 +100,10 @@ pub struct MirrorSettings {
     ///
     #[clap(long, default_value_t = String::from("azurecr.io"))]
     pub registry_host: String,
-    /// If initializing settings, only initialize the hosts.toml file
-    ///
+    /// Minimum initialization,
+    /// 
     #[clap(long, action)]
-    pub init_hosts_config_only: bool,
+    pub min_init: bool,
     /// Root of the current filesystem,
     ///
     /// This is usually just `/` however when testing it's useful to specify since root is a privelaged folder.

--- a/src/bin/shared/commands.rs
+++ b/src/bin/shared/commands.rs
@@ -3,11 +3,10 @@ use lifec::host::HostSettings;
 use lifec::prelude::*;
 use lifec_registry::hosts_config::DefaultHost;
 use lifec_registry::hosts_config::MirrorHost;
-use lifec_registry::ContainerdConfig;
 use lifec_registry::RegistryProxy;
 use std::path::PathBuf;
-use tracing::error;
 use tracing::event;
+use tracing::warn;
 use tracing::info;
 use tracing::Level;
 
@@ -118,11 +117,11 @@ impl Commands {
                 ..
             }) => {
                 if mirror_runmd.exists() {
-                    event!(Level::WARN, "Overwriting existing file {:?}", mirror_runmd);
+                    warn!("Overwriting existing file {:?}", mirror_runmd);
                 }
                 
                 if !min_init {
-                    enable_containerd_config().await;
+                    lifec_registry::enable_containerd_config().await;
 
                     let host_config = if let Some(registry) = registry.as_ref() {
                         MirrorHost::get_hosts_config(
@@ -144,6 +143,8 @@ impl Commands {
                         Ok(path) => event!(Level::INFO, "Wrote hosts.toml for host, {:?}", path),
                         Err(err) => panic!("Could not write hosts.toml {err}"),
                     }
+                } else {
+                    info!("Minimum initialization enabled. Skipping hosts config & containerd config.")
                 }
 
                 tokio::fs::write(
@@ -185,30 +186,6 @@ impl Commands {
                 host.print_lifecycle_graph();
             }
             _ => {}
-        }
-    }
-}
-
-/// Enable containerd config,
-///
-async fn enable_containerd_config() {
-    // Configure containerd
-    let ctr_config = match ContainerdConfig::try_load(None).await {
-        Ok(config) => config,
-        Err(_) => ContainerdConfig::new(),
-    };
-
-    let mut updated = ctr_config
-        .enable_overlaybd_snapshotter()
-        .enable_hosts_config();
-    updated.format();
-
-    match updated.try_save().await {
-        Ok(saved) => {
-            info!("Wrote containerd config at {:?}", saved)
-        }
-        Err(err) => {
-            error!("Could not save containerd config, {err}");
         }
     }
 }

--- a/src/bin/shared/commands.rs
+++ b/src/bin/shared/commands.rs
@@ -121,7 +121,7 @@ impl Commands {
                     event!(Level::WARN, "Overwriting existing file {:?}", mirror_runmd);
                 }
                 
-                if min_init {
+                if !min_init {
                     enable_containerd_config().await;
 
                     let host_config = if let Some(registry) = registry.as_ref() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,3 +18,4 @@ pub use hosts_config::Host;
 
 mod containerd_config;
 pub use containerd_config::ContainerdConfig;
+pub use containerd_config::enable_containerd_config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub use config::HostsConfig;
 pub use config::OAuthConfig;
 pub use config::BearerChallengeConfig;
 pub use config::ContainerdConfig;
+pub use config::enable_containerd_config;
 
 pub mod azure {
     pub use crate::config::AzureAKSConfig;


### PR DESCRIPTION
- This enables the minimum amount to start the mirror and adds query parameters to the /config api. 
- The service definition will only initialize the mirror config, but will skip configuration of containerd and the hosts config.