### PR TITLE
fix: overlaybd URL path, simplify version update and update to latest versions

### DIFF
--- a/lib/sh/overlaybd/install.sh
+++ b/lib/sh/overlaybd/install.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 set -e
 
-# Download Overlaybd binaries
-wget https://github.com/containerd/overlaybd/releases/download/latest/overlaybd-0.6.1-0ubuntu1.22.04.x86_64.deb
-wget https://github.com/containerd/accelerated-container-image/releases/download/latest/overlaybd-snapshotter_0.6.1_amd64.deb
-sudo apt-get install ./overlaybd-0.6.1-0ubuntu1.22.04.x86_64.deb
-sudo apt-get install ./overlaybd-snapshotter_0.6.1_amd64.deb
-rm ./overlaybd-0.6.1-0ubuntu1.22.04.x86_64.deb
-rm ./overlaybd-snapshotter_0.6.1_amd64.deb
+OVERLAYBD_VERSION=0.6.5
+OVERLAYBD_SNAPSHOTTER_VERSION=0.6.2
+UBUNTU_RELEASE=22.04
+# Download Overlaybd binaries 
+wget "https://github.com/containerd/overlaybd/releases/download/v${OVERLAYBD_VERSION}/overlaybd-${OVERLAYBD_VERSION}-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb"
+wget "https://github.com/containerd/accelerated-container-image/releases/download/latest/overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb" # TODO: needs to also suppport ARM64
+sudo apt-get install "./overlaybd-${OVERLAYBD_VERSION}S-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb"
+sudo apt-get install "./overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb"
+rm ./overlaybd-${OVERLAYBD_VERSION}-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb
+rm ./overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb

--- a/lib/sh/overlaybd/install.sh
+++ b/lib/sh/overlaybd/install.sh
@@ -7,7 +7,7 @@ UBUNTU_RELEASE=22.04
 # Download Overlaybd binaries 
 wget "https://github.com/containerd/overlaybd/releases/download/v${OVERLAYBD_VERSION}/overlaybd-${OVERLAYBD_VERSION}-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb"
 wget "https://github.com/containerd/accelerated-container-image/releases/download/latest/overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb" # TODO: needs to also suppport ARM64
-sudo apt-get install "./overlaybd-${OVERLAYBD_VERSION}S-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb"
+sudo apt-get install "./overlaybd-${OVERLAYBD_VERSION}-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb"
 sudo apt-get install "./overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb"
 rm ./overlaybd-${OVERLAYBD_VERSION}-0ubuntu1.${UBUNTU_RELEASE}.x86_64.deb
 rm ./overlaybd-snapshotter_${OVERLAYBD_SNAPSHOTTER_VERSION}_amd64.deb


### PR DESCRIPTION
overlaybd upstream has a new URL format for Ubuntu. Currently the installation script fails because of that.

This also updates the overlaybd and overlaybd snapshotter versions to latest and simplifies the format, to reduce hard-coded changes needed for updates